### PR TITLE
Add Symfony 7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Spotify Web API Bundle
 [![License](https://poser.pugx.org/calliostro/spotify-web-api-bundle/license)](//packagist.org/packages/calliostro/spotify-web-api-bundle)
 
 This bundle provides a simple integration of [jwilsson/spotify-web-api-php](https://github.com/jwilsson/spotify-web-api-php)
-into Symfony 5 or Symfony 6.
+into Symfony 5, Symfony 6 and Symfony 7.
 
 
 Installation

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
     "name": "calliostro/spotify-web-api-bundle",
-    "description": "Spotify Web API client for Symfony 5 or Symfony 6",
+    "description": "Spotify Web API client for Symfony 5, Symfony 6 and Symfony 7",
     "type": "symfony-bundle",
     "require": {
-        "php": "^7.3 || ^8.0",
-        "jwilsson/spotify-web-api-php": "^5.0",
-        "symfony/config": "^5.0 || ^6.0",
-        "symfony/dependency-injection": "^5.0 || ^6.0",
-        "symfony/http-kernel": "^5.0 || ^6.0"
+        "php": "^7.3 || ^8.0 || ^8.1",
+        "jwilsson/spotify-web-api-php": "^5.0 || ^6.0",
+        "symfony/config": "^5.0 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^5.0 || ^6.0 || ^7.0",
+        "symfony/http-kernel": "^5.0 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -15,7 +15,7 @@
         }
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.0 || ^6.0"
+        "symfony/phpunit-bridge": "^5.0 || ^6.0 || ^7.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Spotify Web API client for Symfony 5, Symfony 6 and Symfony 7",
     "type": "symfony-bundle",
     "require": {
-        "php": "^7.3 || ^8.0 || ^8.1",
+        "php": "^7.3 || ^8.0 || ^8.2",
         "jwilsson/spotify-web-api-php": "^5.0 || ^6.0",
         "symfony/config": "^5.0 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^5.0 || ^6.0 || ^7.0",


### PR DESCRIPTION
Hello,

In this Pull Request, I propose the following changes to extend the support of our Symfony bundle to the latest major version, Symfony 7, and to update `jwilsson/spotify-web-api-php` to version 6.

1. **Support for Symfony 7**:
   - Updated version constraints in `composer.json` to allow usage with Symfony 7.
   - Updated documentation to reflect support for Symfony 7.

2. **Update of `jwilsson/spotify-web-api-php` to version 6**:
   - Modified version constraints in `composer.json` to use version 6 of `jwilsson/spotify-web-api-php`.

These updates will allow users to take advantage of the latest features and improvements in Symfony and the Spotify API. I am open to any suggestions to improve these updates.

Thank you for considering this Pull Request.

Best regards,
Yoan
